### PR TITLE
Add LanguagesBuilder Functionality

### DIFF
--- a/source/InnoSetup.ScriptBuilder/Builder/Abstractions/ILanguageEntryBuilder.cs
+++ b/source/InnoSetup.ScriptBuilder/Builder/Abstractions/ILanguageEntryBuilder.cs
@@ -1,0 +1,7 @@
+﻿namespace InnoSetup.ScriptBuilder
+{
+    public interface ILanguageEntryBuilder
+    {
+        LanguagesBuilder CreateEntry(string name, string messageFile);
+    }
+}

--- a/source/InnoSetup.ScriptBuilder/Builder/Abstractions/ILanguageEntryBuilder.cs
+++ b/source/InnoSetup.ScriptBuilder/Builder/Abstractions/ILanguageEntryBuilder.cs
@@ -2,6 +2,6 @@
 {
     public interface ILanguageEntryBuilder
     {
-        LanguagesBuilder CreateEntry(string name, string messageFile);
+        LanguagesBuilder CreateEntry(string name, string messagesFile);
     }
 }

--- a/source/InnoSetup.ScriptBuilder/Builder/IssBuilder.cs
+++ b/source/InnoSetup.ScriptBuilder/Builder/IssBuilder.cs
@@ -5,10 +5,11 @@
 
     public abstract class IssBuilder : IBuilder
     {
-        private readonly SetupBuilder _setup = new ();
-        private readonly FilesBuilder _files = new ();
-        private readonly ComponentsBuilder _components = new ();
-        private readonly RegistryBuilder _registry = new ();
+        private readonly SetupBuilder _setup = new SetupBuilder();
+        private readonly FilesBuilder _files = new FilesBuilder();
+        private readonly ComponentsBuilder _components = new ComponentsBuilder();
+        private readonly RegistryBuilder _registry = new RegistryBuilder();
+        private readonly LanguagesBuilder _languages = new LanguagesBuilder();
 
         public ISetupBuilder Setup => _setup;
 
@@ -18,7 +19,9 @@
 
         public IRegistryBuilder Registry => _registry;
 
-        public GenericSections Sections { get; } = new ();
+        public ILanguageEntryBuilder Languages => _languages;
+
+        public GenericSections Sections { get; } = new GenericSections();
 
         public void Write(TextWriter writer)
         {
@@ -38,7 +41,7 @@
 
         public class GenericSections
         {
-            private readonly List<IBuilder> _builders = new ();
+            private readonly List<IBuilder> _builders = new List<IBuilder>();
 
             public IGenericParameterSectionBuilder CreateParameterSection(string name)
             {

--- a/source/InnoSetup.ScriptBuilder/Builder/IssBuilder.cs
+++ b/source/InnoSetup.ScriptBuilder/Builder/IssBuilder.cs
@@ -27,6 +27,7 @@
         {
             _setup.Write(writer);
             _components.Write(writer);
+            _languages.Write(writer);
             _files.Write(writer);
             _registry.Write(writer);
             Sections.Write(writer);

--- a/source/InnoSetup.ScriptBuilder/Builder/LanguagesBuilder.cs
+++ b/source/InnoSetup.ScriptBuilder/Builder/LanguagesBuilder.cs
@@ -1,0 +1,23 @@
+﻿namespace InnoSetup.ScriptBuilder
+{
+    using Model.LanguageSection;
+
+    public class LanguagesBuilder : ParameterSectionBuilderBase<LanguagesBuilder, LanguageEntry>, ILanguageEntryBuilder
+    {
+        public override string SectionName => "Languages";
+
+        public LanguagesBuilder CreateEntry(string name, string messageFile)
+        {
+            CreateEntryInternal();
+            Name(name);
+            MessageFile(messageFile);
+            return this;
+        }
+
+        private LanguagesBuilder Name(string value) => SetPropertyValue(value);
+        private LanguagesBuilder MessageFile(string value) => SetPropertyValue(value);
+        private LanguagesBuilder LicenseFile(string value) => SetPropertyValue(value);
+        private LanguagesBuilder InfoAfterFile(string value) => SetPropertyValue(value);
+        private LanguagesBuilder InfoBeforeFile(string value) => SetPropertyValue(value);
+    }
+}

--- a/source/InnoSetup.ScriptBuilder/Builder/LanguagesBuilder.cs
+++ b/source/InnoSetup.ScriptBuilder/Builder/LanguagesBuilder.cs
@@ -6,18 +6,18 @@
     {
         public override string SectionName => "Languages";
 
-        public LanguagesBuilder CreateEntry(string name, string messageFile)
+        public LanguagesBuilder CreateEntry(string name, string messagesFile)
         {
             CreateEntryInternal();
             Name(name);
-            MessageFile(messageFile);
+            MessagesFile(messagesFile);
             return this;
         }
 
+        public LanguagesBuilder LicenseFile(string value) => SetPropertyValue(value);
+        public LanguagesBuilder InfoAfterFile(string value) => SetPropertyValue(value);
+        public LanguagesBuilder InfoBeforeFile(string value) => SetPropertyValue(value);
         private LanguagesBuilder Name(string value) => SetPropertyValue(value);
-        private LanguagesBuilder MessageFile(string value) => SetPropertyValue(value);
-        private LanguagesBuilder LicenseFile(string value) => SetPropertyValue(value);
-        private LanguagesBuilder InfoAfterFile(string value) => SetPropertyValue(value);
-        private LanguagesBuilder InfoBeforeFile(string value) => SetPropertyValue(value);
+        private LanguagesBuilder MessagesFile(string value) => SetPropertyValue(value);
     }
 }

--- a/source/InnoSetup.ScriptBuilder/InnoSetup.ScriptBuilder.csproj
+++ b/source/InnoSetup.ScriptBuilder/InnoSetup.ScriptBuilder.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <RootNamespace>InnoSetup.ScriptBuilder</RootNamespace>
-    </PropertyGroup>
-    <PropertyGroup>
-        <Description>InnoSetup Script Builder</Description>
-        <PackageId>InnoSetup.ScriptBuilder</PackageId>
-        <Version>0.1.1</Version>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>InnoSetup.ScriptBuilder</RootNamespace>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Description>InnoSetup Script Builder</Description>
+    <PackageId>InnoSetup.ScriptBuilder</PackageId>
+    <Version>0.1.2</Version>
+  </PropertyGroup>
 </Project>

--- a/source/InnoSetup.ScriptBuilder/Model/LanguageSection/LanguageEntry.cs
+++ b/source/InnoSetup.ScriptBuilder/Model/LanguageSection/LanguageEntry.cs
@@ -1,0 +1,16 @@
+﻿namespace InnoSetup.ScriptBuilder.Model.LanguageSection
+{
+    using FileSection;
+    public class LanguageEntry : ParameterSectionEntryBase
+    {
+        public string Name { get; set; }
+
+        public string MessagesFile { get; set; }
+
+        public string LicenseFile { get; set; }
+
+        public string InfoAfterFile { get; set; }
+
+        public string InfoBeforeFile { get; set; }
+    }
+}


### PR DESCRIPTION
Add LanguagesBuilder Functionality.

C#
``` C#
Languages.CreateEntry(name: "en", messagesFile: @"compiler:Default.isl");
Languages.CreateEntry(name: "br", messagesFile: @"compiler:Languages\BrazilianPortuguese.isl")
    .LicenseFile("License.rtf");
```

iss
```iss
[Languages]
Name: "en"; MessagesFile: "compiler:Default.isl"; 
Name: "br"; MessagesFile: "compiler:Languages\BrazilianPortuguese.isl"; LicenseFile: "License.rtf"; 
```